### PR TITLE
Handle invalid % character at the end of EdDSA public key in Info.plist

### DIFF
--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -132,7 +132,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *_Nullable)publicEDKey SPU_OBJC_DIRECT
 {
-    return [self objectForInfoDictionaryKey:SUPublicEDKeyKey];
+    NSString *publicKey = [self objectForInfoDictionaryKey:SUPublicEDKeyKey];
+    if [publicKey substringFromIndex:[publicKey length] - 1] == @"%" {
+        return [publicKey substringToIndex:[publicKey length] - 1]
+    }
+    return publicKey
 }
 
 - (NSString *_Nullable)publicDSAKey SPU_OBJC_DIRECT


### PR DESCRIPTION
This change ignores invalid % character at the end of Base64 encoded EdDSA public key in Info.plist file. Some Base64 encoders add it at the end and Sparkle 2 is not able to load such key.